### PR TITLE
added github action to build node & desktop on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ windows-2019, ubuntu-20.04] #macos-10.15,
+        os: [ windows-2019, ubuntu-20.04, macos-10.15],
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
After adding need to remove nightly build from Node gitlab pipeline

Secrets should be added to repo:

- github_token
- mac_certs
- mac_certs_password
- windows_certs
- windows_certs_password
- APPLEID
- APPLEIDPASS
- FASTLANE_ANDROID_SIGNING_FILE_VALUE
- FASTLANE_ANDROID_SIGNING_FILE_PATH
- FASTLANE_ANDROID_SECRET_JSON_VALUE
- FASTLANE_ANDROID_SECRET_JSON_PATH
- GOOGLE_SERVICES_VALUE
- GOOGLE_SERVICES_PATH
